### PR TITLE
building in windows from sources, tested in VS14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+build/

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,138 +3,66 @@ import sys
 import os
 
 
-class glfw3Conan(ConanFile):
-	name    = "glfw"
-	version = "3.2"
-	license = "zlib/libpng License"
+class glfw3Conan( ConanFile ):
+    name = "glfw"
+    version = "3.2"
+    license = "zlib/libpng License"
 
-	url = "https://github.com/GavinNL/conan_glfw"
+    url = "https://github.com/GavinNL/conan_glfw"
+    options = {"shared": [True, False]}
+    default_options = "shared=False"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
 
-	options = { "shared"            : [True, False] 
-		      }
+    def source( self ):
+        zip_name = "glfw-3.2.zip"
+        tools.download("https://github.com/glfw/glfw/releases/download/3.2/glfw-3.2.zip", zip_name)    
+        tools.unzip(zip_name)
+        os.unlink(zip_name)
+        tools.replace_in_file("glfw-3.2/CMakeLists.txt", "project(GLFW C)", """project(GLFW C)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+        """)
 
-	default_options = "shared=False"
+    def config(self):
+        # It is a pure C project, the libcxx setting is not relevant at all
+        del self.settings.compiler.libcxx
 
-	settings = "os", "compiler", "build_type", "arch"
+    def system_requirements( self ):
+        if self.settings.os == "Linux":
+            self.run( 'sudo apt-get install xorg-dev' )
+            self.run( 'sudo apt-get install libgl1-mesa-dev' )
+            self.run( 'sudo apt-get install libglew-dev' )
+        elif self.settings.os == "Macos":
+            print( "  ***************** Need Help here **************** " )
+            print( "  Mac OS not implemented yet. Please help out! **** " )
+            print( "  ***************** Need Help here **************** " )
+            sys.exit( 1 )
 
+    def build( self ):  
+        cmake = CMake( self.settings )
+        
+        args = ["-DBUILD_SHARED_LIBS=ON"  if self.options.shared else "-DBUILD_SHARED_LIBS=OFF"]
+        args += ["-DGLFW_BUILD_DOCS=OFF" ]
+        args += ["-DGLFW_BUILD_EXAMPLES=OFF" ]
+        args += ["-DGLFW_BUILD_TESTS=OFF" ]
+        args += ['-DCMAKE_INSTALL_PREFIX="%s"' % self.package_folder]
+        
+        self.run('cmake %s/glfw-3.2 %s %s'
+                  % (self.conanfile_directory, cmake.command_line, ' '.join( args ) ) )
+        self.run("cmake --build . --target install %s" % cmake.build_config)
 
-	def source(self):
-
-		if self.settings.os == "Windows":
-
-			if self.settings.arch == "x86":
-				zip_name = "glfw-3.2.bin.WIN32.zip" 
-				tools.download("https://github.com/glfw/glfw/releases/download/3.2/glfw-3.2.bin.WIN32.zip", zip_name)
-			else:
-				zip_name = "glfw-3.2.bin.WIN64.zip"
-				tools.download("https://github.com/glfw/glfw/releases/download/3.2/glfw-3.2.bin.WIN64.zip", zip_name)
-
-		else:
-
-			zip_name = "glfw-3.2.zip"
-			tools.download("https://github.com/glfw/glfw/releases/download/3.2/glfw-3.2.zip", zip_name)
-
-		tools.unzip(zip_name)
-		os.unlink(zip_name)
-          
-
-	def system_requirements(self):
-
-		if self.settings.os == "Linux":
-
-			self.run('sudo apt-get install xorg-dev')        
-			self.run('sudo apt-get install libgl1-mesa-dev')
-			self.run('sudo apt-get install libglew-dev')
-
-		elif self.settings.os == "Macos":
-			print("  ***************** Need Help here **************** ")
-			print("  Mac OS not implemented yet. Please help out! **** ")
-			print("  ***************** Need Help here **************** ")
-			sys.exit(1)
-
-		# No requirements for windows since we are using the prepackaged binaries provided by the developers
-
-
-	def build(self):
-
-		if self.settings.os == "Linux":
-
-			cmake = CMake(self.settings)
-
-			args  = ["-DBUILD_SHARED_LIBS=ON"    if self.options.shared           else "-DBUILD_SHARED_LIBS=OFF"]
-			args += ["-DGLFW_BUILD_DOCS=OFF" ]
-			args += ["-DGLFW_BUILD_EXAMPLES=OFF" ]
-			args += ["-DGLFW_BUILD_TESTS=OFF" ]
-			args += ['-DCMAKE_INSTALL_PREFIX=install']
-
-			self.run('cd %s' % self.conanfile_directory )
-			self.run('cmake %s/glfw-3.2 %s %s' % ( self.conanfile_directory, cmake.command_line, ' '.join(args) ) )
-			self.run("cmake --build . --target install %s" % cmake.build_config )
-			self.run("echo cmake --build . --target install %s" % cmake.build_config )
-
-
-			if self.settings.arch == "x86":
-				folder = "glfw-3.2.bin.WIN32"
-			else:
-				folder = "glfw-3.2.bin.WIN64"
-
-
-	def package(self):
-
-		# If we are on windows, just download the binary provided by the dev team
-		# rather than compiling it ourself, they provide binaries for mingw, VC11, VC12 and VC14
-		if self.settings.os == "Windows":
-
-			if self.settings.arch == "x86":
-				folder = "glfw-3.2.bin.WIN32"
-			else:
-				folder = "glfw-3.2.bin.WIN64"
-
-			self.copy("*",     dst="include", src="%s/include"%folder)
-
-			if self.settings.compiler == "gcc" : 
-
-				if self.settings.arch == "x86":
-					LibDir = "%s/lib-mingw"%folder
-				else:
-					LibDir = "%s/lib-mingw-w64"%folder
-
-				if self.options.shared:
-					self.copy("libglfw3dll.a",     dst="lib",     src=LibDir )
-					self.copy("glfw3.dll",         dst="lib",     src=LibDir )				           
-				else:
-					self.copy("libglfw3.a",           dst="lib",     src=LibDir )
-
-
-			elif self.settings.compiler == "Visual Studio":
-
-				v = self.settings.compiler.version
-
-				if v == "14":				
-					LibDir = "%s/lib-vc2015" % folder
-				elif v == "12":
-					LibDir = "%s/lib-vc2013" % folder
-				elif v == "11":
-					LibDir = "%s/lib-vc2012" % folder
-
-				if self.options.shared:
-					self.copy("glfw3dll.lib",     dst="lib",     src=LibDir)
-					self.copy("glfw3.dll",        dst="lib",     src=LibDir)
-				else:
-					self.copy("glfw3.lib",        dst="lib",     src=LibDir)
-
-		else:
-			self.copy("*",     dst="include", src="install/include")
-			self.copy("*",     dst="lib",     src="install/lib")
-			self.copy("*",     dst="bin",     src="install/bin")
-
-	def package_info(self):
-		if self.settings.os == "Linux":
-			self.cpp_info.libs = [ "glfw3", "rt", "m" ,"dl" ,"Xrandr" ,"Xinerama", "Xxf86vm" ,"Xext" ,"Xcursor", "Xrender" ,"Xfixes", "X11", "pthread", "xcb" ,"Xau", "Xdmcp", "GL", "GLEW" ]
-		elif self.settings.os == "Windows":
-			self.cpp_info.libs = [ "glfw3", "GL", "GLEW" ]
-
-		elif self.settings.os == "Macos":
-			self.cpp_info.libs = [ "glfw3", "GL", "GLEW" ]
+    def package( self ): 
+        pass # already installed in build
+    
+    def package_info( self ):
+        if self.settings.os == "Linux":
+            self.cpp_info.libs = [ "glfw3", "rt", "m" , "dl" , "Xrandr" , "Xinerama", "Xxf86vm" , 
+                                  "Xext" , "Xcursor", "Xrender" , "Xfixes", "X11", "pthread", 
+                                  "xcb" , "Xau", "Xdmcp", "GL", "GLEW" ]
+        elif self.settings.os == "Windows":
+            self.cpp_info.libs = [ "glfw3", "opengl32" ]
+        elif self.settings.os == "Macos":
+            self.cpp_info.libs = [ "glfw3", "GL", "GLEW" ]
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,14 @@
 project(glfw_test)
 cmake_minimum_required(VERSION 2.8.12)
 
-include_directories(${glfw_test_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 
 conan_basic_setup()
 
-ADD_DEFINITIONS ( -std=c++11 )
+if(NOT MSVC)
+  ADD_DEFINITIONS ( -std=c++11 )
+endif()
 
 add_executable(glfw_test main.cpp glad.c)
 target_link_libraries(glfw_test ${CONAN_LIBS})

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, CMake
+import os
+
+channel = os.getenv("CONAN_CHANNEL", "stable")
+username = os.getenv("CONAN_USERNAME", "memsharded")
+
+class ZMQTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    requires = "glfw/3.2@GavinNL/testing"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self.settings)
+        self.run('cmake "%s" %s' % (self.conanfile_directory, cmake.command_line))
+        self.run("cmake --build . %s" % cmake.build_config)
+
+    def imports(self):
+        self.copy("*.dll", "bin", "bin")
+        self.copy("*.dylib", "bin", "lib")
+
+    def test(self):
+        os.chdir("bin")
+        self.run(".%sglfw_test" % os.sep)


### PR DESCRIPTION
Hi Gavin!

You did a great job with this package!

I prefer to build from sources whenever possible, it is more flexible, powerful... even the conanfile can be simplified. I have forked your repo and did some changes, tested it in MSVC 14:

- I have applied some formatting (python pep8), thats why the file looks with many changes, though I have not changed all of it
- Building from sources in Win too
- Using ``cmake install`` feature to implement the ``package()`` functionality => simple and less lines
- Removing ``libcxx`` setting, as it is a pure C project
- I had to replace GL=>opengl32 and remove GLEW libraries. They don't exist in VS, do they? Where they come from? It seems to work without them
- By adding ``conan_basic_setup()`` to the glfw CMakeLists, I can set proper MD/MT flags. Maybe can be done easier with the glfw CMakeLists options.

I might have broken something in Linux or other VS versions (or using shared/static option). So maybe this is not fully ready for merge, or you just don't like the approach (it is fine :)  I just wanted to share with you it. I will check other VS versions, Linux and OSX too when possible. 
Cheers!